### PR TITLE
Add quickstart command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,9 @@ cargo build --release
 ### Basic Usage
 
 ```bash
+# Start quickly with defaults
+cargo run --bin messenger quickstart --name "Your Name"
+
 # Generate a new identity
 cargo run --bin messenger keys generate --name "Your Name"
 


### PR DESCRIPTION
## Summary
- add new `quickstart` subcommand to quickly start the messenger
- generate default config and identity if missing and then run the app
- document the quickstart command in the README

## Testing
- `cargo check --quiet`
- `cargo test --quiet` *(fails: test_x3dh_without_one_time_prekey, test_x3dh_key_agreement, test_message_serialization)*

------
https://chatgpt.com/codex/tasks/task_e_6885c8930a2c8331930da3544a12270e